### PR TITLE
feat(bot): auto refresh on ParseCommand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           version: latest
           skip-pkg-cache: true
+          args: --timeout=30m
   tests:
     runs-on: ubuntu-latest
     permissions: write-all

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -1,6 +1,8 @@
 package bot
 
 import (
+	"time"
+
 	"github.com/erdnaxeli/rudolphe/aoc"
 	"github.com/erdnaxeli/rudolphe/leaderboard"
 )
@@ -24,6 +26,8 @@ type Bot interface {
 type bot struct {
 	aocClient       aoc.Client
 	leaderBoardRepo leaderboard.Repository
+
+	lastRefresh time.Time
 }
 
 func New(

--- a/bot/parse_command.go
+++ b/bot/parse_command.go
@@ -3,9 +3,29 @@ package bot
 import (
 	"strconv"
 	"time"
+
+	"golang.org/x/exp/slog"
 )
 
 func (b bot) ParseCommand(msg string) (Result, error) {
+	result, err := b.parseCommand(msg)
+	if err != nil {
+		return result, err
+	}
+
+	if time.Since(b.lastRefresh) >= 15*time.Minute {
+		refreshResult, err := b.Refresh()
+		if err != nil {
+			slog.Warn("Error while auto refreshing", "error", err)
+		} else {
+			result.Messages = append(result.Messages, refreshResult.Messages...)
+		}
+	}
+
+	return result, nil
+}
+
+func (b bot) parseCommand(msg string) (Result, error) {
 	if msg == "!lb" {
 		now := time.Now()
 		year := now.Year()

--- a/bot/refresh.go
+++ b/bot/refresh.go
@@ -12,6 +12,7 @@ import (
 func (b bot) Refresh() (Result, error) {
 	result := Result{}
 	now := time.Now()
+	b.lastRefresh = now
 
 	for year := now.Year(); year >= 2015; year-- {
 		slog.Info("Updating leaderboard", "year", year)


### PR DESCRIPTION
If we receive a message and the elapsed time since the last refresh is more that 15 minutes, we trigger a refresh.