### PR TITLE
feat(makefile): add a new target "compat"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,22 @@ else
 endif
 
 
-all: build
+all: compat
 
 build:
 	$(GO) build -ldflags="-s -w" ./cmd/rudolphe
 
+compat:
+	docker run --rm -it \
+		-v ${PWD}:/src \
+		-v gopkgmod:/go/pkg/mod \
+		-v gobuildcache:/root/.cache/go-build \
+		golang:1.21-bullseye \
+		bash -c "\
+			cd /src && \
+			git config --global --add safe.directory /src && \
+			go build -ldflags='-s -w' ./cmd/rudolphe \
+		"
 
 style:
 	$(GO) fmt ./...


### PR DESCRIPTION
This target build the project using a debian 11 container in order to link with the glibc v2.31. It uses volumes to save go caches.

The downside so far is that the final binary is owned by root.